### PR TITLE
Chord Name display

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,6 @@ Chords.guitar.matching(group: .suspended)
 Swifty Chords suports a number of alternative texts you can use in your UI including an accessibility text-to-speech friendly variant.
 Display texts from both Key and Suffix properties can be combined to complete the chord name.
 
-NOTE: These are new additions and currently don't work with the drawing portion of the library. All chord names are drawn using the `RawValue` on the Key and Suffix properties. There is an open issue for this.
-
 ```
 let cMajSevenFlatFive = Chords.guitar.matching(key: .c).matching(suffix: .majorSevenFlatFive)
 print(cMajSevenFlatFive.suffix.display.accessible) // " major seven flat five"
@@ -82,7 +80,7 @@ To use it, we just need a chord!
 ```
 let chordPosition = Chords.guitar.matching(key: .c).matching(suffix: .major).first!
 let frame = CGRect(x: 0, y: 0, width: 100, height: 150) // I find these sizes to be good.
-let layer = chordPosition.shapeLayer(rect: frame)
+let layer = chordPosition.chordLayer(rect: frame, chordName: .init(show: true, key: .symbol, suffix: .symbolized))
 imageView.image = layer.image() // might be expensive. Use Layers when possible while drawing to a view. Images are better if you plan to send them outside the app.
 ```
 
@@ -91,7 +89,7 @@ imageView.image = layer.image() // might be expensive. Use Layers when possible 
 
 `showFingers`: Determines if the finger numbers should be drawn on top of the dots. Default `true`.
 
-`showChordName` Determines if the chord name should be drawn above the chord. Choosing this option will reduce the size of the chord chart slightly to account for the text. Default `true`.
+`showChordName` Determines if the chord name should be drawn above the chord. Choosing this option will reduce the size of the chord chart slightly to account for the text. Default `true`. The display mode can be set for Key and Suffix. Default `rawValue`
 
 `forPrint`: If set to `true` the diagram will be colored Black, ignoring the users device settings. If set to `false`, the color of the diagram will match the system label color. Dark text for light mode, and Light text for dark mode. Default `false`.
 

--- a/Sources/SwiftyChords/Chords.swift
+++ b/Sources/SwiftyChords/Chords.swift
@@ -22,7 +22,7 @@ public struct Chords {
         case b = "B"
         
         /// Contains text for accessibility text-to-speech and symbolized versions.
-        var display: (accessible: String, symbol: String) {
+        public var display: (accessible: String, symbol: String) {
             switch self {
             case .c:
                 return ("C", "C")
@@ -130,7 +130,7 @@ public struct Chords {
         /// Symbols use superscript where appropriate (and possible). Be aware that not all fonts will support this. Use `short` instead if you're unsure.
         ///
         /// Some items may also be identical across types. Only in rare cases will an alt symbol be provided e.g. (`dim⁷`,`°`)
-        var display: (accessible: String, short: String, symbolized: String, altSymbol: String) {
+        public var display: (accessible: String, short: String, symbolized: String, altSymbol: String) {
             switch self {
             case .major:
                 return (" major", "Maj", "M", "M")
@@ -282,6 +282,38 @@ public struct Chords {
         }
     }
 
+    /// Display options for the chord name
+    public struct Name {
+        /// Init the struct
+        public init(show: Bool = true, key: Name.Display.Key = .raw, suffix: Name.Display.Suffix = .raw) {
+            self.show = show
+            self.key = key
+            self.suffix = suffix
+        }
+        /// Show the name in the chord shape
+        public var show: Bool
+        /// Display of the Key value
+        public var key: Display.Key
+        /// Display of the Suffix value
+        public var suffix: Display.Suffix
+        /// Display modus of the chord name
+        public enum Display {
+            /// Key display modus
+            public enum Key {
+                case raw
+                case accessible
+                case symbol
+            }
+            /// Suffix display modus
+            public enum Suffix {
+                case raw
+                case short
+                case symbolized
+                case altSymbol
+            }
+        }
+    }
+    
     public static var guitar = Chords.readData(for: "GuitarChords")
     public static var ukulele = Chords.readData(for: "UkuleleChords")
 


### PR DESCRIPTION
First of all, thanks for you package Beau Nouvelle!

https://github.com/BeauNouvelle/SwiftyGuitarChords/issues/20

I added options to set the Chord Name display in the drawing function.

- Renamed 'shapeLayer' to 'chordLayer'
- Fully backwards compatible
- Updated 'README'