### PR TITLE
Add the missing keys to the Key enum

### DIFF
--- a/Sources/SwiftyChords/Chords.swift
+++ b/Sources/SwiftyChords/Chords.swift
@@ -10,12 +10,14 @@ public struct Chords {
     public enum Key: String, CaseIterable, Codable, Comparable {
         case c = "C"
         case cSharp = "C#"
+        case dFlat = "Db"
         case d = "D"
         case dSharp = "D#"
         case eFlat = "Eb"
         case e = "E"
         case f = "F"
         case fSharp = "F#"
+        case gFlat = "Gb"
         case g = "G"
         case gSharp = "G#"
         case aFlat = "Ab"
@@ -36,6 +38,8 @@ public struct Chords {
                 return ("C", "C")
             case .cSharp:
                 return ("C sharp", "C♯")
+            case .dFlat:
+                return ("D flat", "D♭")
             case .d:
                 return ("D", "D")
             case .dSharp:
@@ -48,6 +52,8 @@ public struct Chords {
                 return ("F", "F")
             case .fSharp:
                 return ("F sharp", "F♯")
+            case .gFlat:
+                return ("G flat", "G♭")
             case .g:
                 return ("G", "G")
             case .gSharp:

--- a/Sources/SwiftyChords/Chords.swift
+++ b/Sources/SwiftyChords/Chords.swift
@@ -7,7 +7,7 @@ public struct Chords {
         case major, minor, diminished, augmented, suspended, other
     }
 
-    public enum Key: String, CaseIterable, Codable {
+    public enum Key: String, CaseIterable, Codable, Comparable {
         case c = "C"
         case cSharp = "C#"
         case d = "D"
@@ -23,6 +23,11 @@ public struct Chords {
         case aSharp = "A#"
         case bFlat = "Bb"
         case b = "B"
+        
+        /// Implement Comparable
+        public static func < (lhs: Self, rhs: Self) -> Bool {
+            return allCases.firstIndex(of: lhs)! < allCases.firstIndex(of: rhs)!
+        }
         
         /// Contains text for accessibility text-to-speech and symbolized versions.
         public var display: (accessible: String, symbol: String) {
@@ -61,7 +66,7 @@ public struct Chords {
         }
     }
 
-    public enum Suffix: String, CaseIterable, Codable {
+    public enum Suffix: String, CaseIterable, Codable, Comparable {
         case major = "major"
         case minor = "minor"
         case dim = "dim"
@@ -124,6 +129,11 @@ public struct Chords {
         case minorSlashFSharp = "m/F#"
         case minorSlashG = "m/G"
         case minorSlashGSharp = "m/G#"
+        
+        /// Implement Comparable
+        public static func < (lhs: Self, rhs: Self) -> Bool {
+            return allCases.firstIndex(of: lhs)! < allCases.firstIndex(of: rhs)!
+        }
         
         /// A suitible string for displaying to users.
         /// - `accessible:`  "seven flat five". Useful for text to speech.

--- a/Sources/SwiftyChords/Chords.swift
+++ b/Sources/SwiftyChords/Chords.swift
@@ -11,13 +11,16 @@ public struct Chords {
         case c = "C"
         case cSharp = "C#"
         case d = "D"
+        case dSharp = "D#"
         case eFlat = "Eb"
         case e = "E"
         case f = "F"
         case fSharp = "F#"
         case g = "G"
+        case gSharp = "G#"
         case aFlat = "Ab"
         case a = "A"
+        case aSharp = "A#"
         case bFlat = "Bb"
         case b = "B"
         
@@ -30,6 +33,8 @@ public struct Chords {
                 return ("C sharp", "C♯")
             case .d:
                 return ("D", "D")
+            case .dSharp:
+                return ("D sharp", "D♯")
             case .eFlat:
                 return ("E flat", "E♭")
             case .e:
@@ -40,10 +45,14 @@ public struct Chords {
                 return ("F sharp", "F♯")
             case .g:
                 return ("G", "G")
+            case .gSharp:
+                return ("G sharp", "G♯")
             case .aFlat:
                 return ("A flat", "A♭")
             case .a:
                 return ("A", "A")
+            case .aSharp:
+                return ("A sharp", "A♯")
             case .bFlat:
                 return ("B flat", "B♭")
             case .b:


### PR DESCRIPTION
Also, make the Key and Suffix enums confirm to Comparable so they can be sorted.

This PR does not add any chords to the database for the missing keys but it is possible now.