### PR TITLE
Make the init of ChordPosition public

### DIFF
--- a/Sources/SwiftyChords/ChordPosition.swift
+++ b/Sources/SwiftyChords/ChordPosition.swift
@@ -15,6 +15,19 @@ import AppKit
 #endif
 
 public struct ChordPosition: Codable, Identifiable, Equatable {
+    
+    public init(id: UUID = UUID(), frets: [Int], fingers: [Int], baseFret: Int, barres: [Int], capo: Bool? = nil, midi: [Int], key: Chords.Key, suffix: Chords.Suffix) {
+        self.id = id
+        self.frets = frets
+        self.fingers = fingers
+        self.baseFret = baseFret
+        self.barres = barres
+        self.capo = capo
+        self.midi = midi
+        self.key = key
+        self.suffix = suffix
+    }
+    
     public var id: UUID = UUID()
 
     public let frets: [Int]


### PR DESCRIPTION
Because ChordPosition has no init itself; it wil have a member-wise init with internal access level.

That means you can't create a new ChordPosition structs to add or edit chords unless you use a JSONDecoder(). It is not possible to add an 'init' in an extention to ChordPosition.

This commit adds a 'public' init.